### PR TITLE
Concave hull for NetCDF Utils

### DIFF
--- a/geophys_utils/_concave_hull.py
+++ b/geophys_utils/_concave_hull.py
@@ -245,7 +245,7 @@ def concave_hull_indices(dataset, k):
     return hull
 
 
-def concaveHull(dataset, k):
+def concaveHull(dataset, k=3):
     assert k >= 3, 'k has to be greater or equal to 3.'
 
     return dataset[concave_hull_indices(dataset, k), :]

--- a/geophys_utils/_concave_hull.py
+++ b/geophys_utils/_concave_hull.py
@@ -1,0 +1,251 @@
+#!/bin/env python
+"""
+Calculate the concave hull of a set of points.
+
+Adapted from Adriano Moreira and Maribel Yasmina Santos 2007.
+"""
+
+import numpy as np
+import scipy.spatial as spt
+from matplotlib.path import Path
+
+
+def bbox(a, b):
+    return {
+        'll_x': min(a[0], b[0]),
+        'll_y': min(a[1], b[1]),
+        'ur_x': max(a[0], b[0]),
+        'ur_y': max(a[1], b[1])
+    }
+
+
+def doBoundingBoxesIntersect(b1, b2):
+    """
+    Check if bounding boxes do intersect. If one bounding box touches
+    the other, they do intersect.
+    """
+    if b1['ll_x'] > b2['ur_x']:
+        return False
+
+    if b1['ur_x'] < b2['ll_x']:
+        return False
+
+    if b1['ll_y'] > b2['ur_y']:
+        return False
+
+    if b1['ur_y'] < b2['ll_y']:
+        return False
+
+    return True
+
+
+def isPointOnLine(a, b, c):
+    """ Check if a point is on a line. """
+    # move to origin
+    bTmp = (b[0] - a[0], b[1] - a[1])
+    cTmp = (c[0] - a[0], c[1] - a[1])
+    r = np.cross(bTmp, cTmp)
+    return np.abs(r) < 0.0000000001
+
+
+def isPointRightOfLine(a, b, c):
+    """
+    Check if a point (c) is right of a line (a-b).
+    If (c) is on the line, it is not right it.
+    """
+    # move to origin
+    bTmp = (b[0] - a[0], b[1] - a[1])
+    cTmp = (c[0] - a[0], c[1] - a[1])
+    return np.cross(bTmp, cTmp) < 0
+
+
+def lineSegmentTouchesOrCrossesLine(a, b, c, d):
+    """
+    Check if line segment (a-b) touches or crosses
+    line segment (c-d).
+    """
+    return isPointOnLine(a, b, c) or \
+           isPointOnLine(a, b, d) or \
+          (isPointRightOfLine(a, b, c) ^
+           isPointRightOfLine(a, b, d))
+
+
+def doLinesIntersect(a, b, c, d):
+    """ Check if line segments (a-b) and (c-d) intersect. """
+    if not lineSegmentTouchesOrCrossesLine(a, b, c, d):
+        return False
+
+    return lineSegmentTouchesOrCrossesLine(c, d, a, b)
+
+
+class PointSet:
+    """ Book-keeping for an array of points. """
+
+    def __init__(self, points):
+        """ Create a kD-tree from the points. """
+        npoints, ndim = points.shape
+        assert ndim == 2
+        self.points = points
+        self.tree = spt.cKDTree(points, leafsize=10)
+
+        # keep track of which points are currently still under consideration
+        self.registry = np.full((npoints, ), fill_value=True, dtype='bool')
+
+        # remove duplicates
+        for i in range(npoints):
+            mask = np.all(points == points[i], axis=1)
+            self.registry[mask] = False
+            self.registry[i] = True
+            npoints = npoints - np.count_nonzero(mask) + 1
+
+        assert np.count_nonzero(self.registry) == npoints
+        self.npoints = npoints
+
+    def __getitem__(self, index):
+        return self.points[index]
+
+    def start(self):
+        """ The index of the starting point (the point with the lowest y-value). """
+        for i in np.argsort(self[:, 1]):
+            if self.registry[i]:
+                return i
+
+        raise ValueError("no starting point to pick")
+
+    def remove(self, index):
+        self.registry[index] = False
+        self.npoints = self.npoints - 1
+
+    def restore(self, index):
+        self.registry[index] = True
+        self.npoints = self.npoints + 1
+
+    def nearest_neighbors(self, current_point, k):
+        """
+        Return the indices of the k nearest neighbors (or fewer if not enough points left).
+        """
+        kk = k
+
+        while True:
+            distances, indices = self.tree.query(current_point, kk)
+            indices = [index for index in indices if self.registry[index]]
+            assert len(indices) <= self.npoints
+            if len(indices) == k or len(indices) == self.npoints:
+                return indices
+            kk = kk + 1
+
+
+def TurningAngle(NearestPoint, currentPoint, previousAngle):
+    angle = np.arctan2(NearestPoint[1] - currentPoint[1],
+                       NearestPoint[0] - currentPoint[0]) - previousAngle
+    angle = np.rad2deg(angle)
+    if angle <= 0.:
+        angle += 360.
+    return angle
+
+
+def GetNearestNeighbors(dataset, point, k):
+    return dataset[PointSet(dataset).nearest_neighbors(point, k), :]
+
+
+def sort_by_angle_indices(kNearestPoints, currentPoint, prevPoint):
+    """ Sorts the k nearest points given by angle. """
+    angles = np.zeros(kNearestPoints.shape[0])
+    previousAngle = np.arctan2(prevPoint[1] - currentPoint[1],
+                               prevPoint[0] - currentPoint[0])
+
+    i = 0
+    for NearestPoint in kNearestPoints:
+        # calculate the angle
+        # only positive angles
+        angles[i] = TurningAngle(NearestPoint, currentPoint, previousAngle)
+        i = i + 1
+    return np.argsort(angles)
+
+
+def SortByAngle(kNearestPoints, currentPoint, prevPoint):
+    return kNearestPoints[sort_by_angle_indices(kNearestPoints, currentPoint,
+                                                prevPoint), :]
+
+
+def first_valid_candidate(point_set, cPoints, hull, first, step):
+    # avoid intersections: select first candidate that does not intersect any
+    # polygon edge
+    def intersects(candidate, lastPoint):
+        a = point_set[candidate]
+        b = point_set[hull[step - 2]]
+        b1 = bbox(a, b)
+
+        for j in range(2, len(hull) - lastPoint):
+            c = point_set[hull[step - j - 2]]
+            d = point_set[hull[step - j - 1]]
+            b2 = bbox(c, d)
+
+            if doBoundingBoxesIntersect(b1, b2) and \
+                    doLinesIntersect(a, b, c, d):
+                return True
+
+        return False
+
+    for candidate in cPoints:
+        if candidate == first:
+            lastPoint = 1
+        else:
+            lastPoint = 0
+
+        if not intersects(candidate, lastPoint):
+            return candidate
+
+    return None
+
+
+def concave_hull_indices(dataset, k):
+    point_set = PointSet(dataset)
+    # todo: make sure that enough points for a given k can be found
+
+    first = point_set.start()
+    # init hull as list to easily append stuff
+    hull = [first]
+    # and remove it from dataset
+    point_set.remove(first)
+
+    current = first
+    # set prevPoint to a Point righ of currentpoint (angle=0)
+    prev = np.array([point_set[current, 0] - 1, point_set[current, 1]])
+    step = 2
+
+    while (first != current or (step == 2)) and point_set.npoints > 0:
+        if step == 5:
+            # we're far enough to close too early, so put first back again
+            point_set.restore(first)
+
+        k_nearest = point_set.nearest_neighbors(point_set[current], k)
+        cPoints = sort_by_angle_indices(point_set[k_nearest, :],
+                                        point_set[current], prev)
+        cPoints = np.array(k_nearest)[cPoints]
+        prev = point_set[current]
+
+        current = first_valid_candidate(point_set, cPoints, hull, first, step)
+        if current is None:
+            return concave_hull_indices(dataset, k + 1)
+
+        # add current point to hull
+        hull.append(current)
+        point_set.remove(current)
+
+        step = step + 1
+
+    # check if all points are inside the hull
+    p = Path(point_set.points[hull, :])
+
+    pContained = p.contains_points(dataset, radius=0.0000000001)
+    if not pContained.all():
+        return concave_hull_indices(dataset, k + 1)
+
+    return hull
+
+
+def concaveHull(dataset, k):
+    assert k >= 3, 'k has to be greater or equal to 3.'
+
+    return dataset[concave_hull_indices(dataset, k), :]

--- a/geophys_utils/_netcdf_grid_utils.py
+++ b/geophys_utils/_netcdf_grid_utils.py
@@ -25,8 +25,10 @@ import math
 from scipy.ndimage import map_coordinates
 from geophys_utils._crs_utils import get_utm_wkt, transform_coords
 from geophys_utils._transect_utils import sample_transect
-from geophys_utils._polygon_utils import netcdf2convex_hull
+from geophys_utils._polygon_utils import netcdf2convex_hull, get_grid_edge_points
 from geophys_utils._netcdf_utils import NetCDFUtils
+from geophys_utils._concave_hull import concaveHull
+from shapely.geometry import shape
 import logging
 import argparse
 from distutils.util import strtobool
@@ -371,6 +373,15 @@ class NetCDFGridUtils(NetCDFUtils):
             
         return transform_coords(convex_hull, self.wkt, to_wkt)
 
+    def get_concave_hull(self):
+        """ Returns the concave hull (as a shapely polygon) of points with data. """
+        edge_points = np.array(get_grid_edge_points(self.data_variable,
+                                                    self.dimension_arrays,
+                                                    self.data_variable._FillValue))
+        hull = concaveHull(edge_points, 3)
+        return shape({'type': 'Polygon', 'coordinates': [hull.tolist()]})
+
+
     @property
     def GeoTransform(self):
         '''
@@ -456,4 +467,4 @@ def main():
         
 
 if __name__ == '__main__':
-    main()        
+    main()

--- a/geophys_utils/_netcdf_grid_utils.py
+++ b/geophys_utils/_netcdf_grid_utils.py
@@ -378,7 +378,7 @@ class NetCDFGridUtils(NetCDFUtils):
         edge_points = np.array(get_grid_edge_points(self.data_variable,
                                                     self.dimension_arrays,
                                                     self.data_variable._FillValue))
-        hull = concaveHull(edge_points, 3)
+        hull = concaveHull(edge_points)
         return shape({'type': 'Polygon', 'coordinates': [hull.tolist()]})
 
 

--- a/geophys_utils/_netcdf_line_utils.py
+++ b/geophys_utils/_netcdf_line_utils.py
@@ -381,7 +381,7 @@ class NetCDFLineUtils(NetCDFPointUtils):
         #logger.debug('line_index: {}'.format(line_index))
         return line_index
 
-    def get_concave_hull(self, buffer=None):
+    def get_concave_hull(self, smoothness=None):
         def end_points(ld):
             coords = ld['coordinates']
             assert len(coords.shape) == 2
@@ -393,6 +393,6 @@ class NetCDFLineUtils(NetCDFPointUtils):
         points = np.concatenate([end_points(ld) for _, ld in self.get_lines(variables=[])])
         hull = concaveHull(points)
         result = shape({'type': 'Polygon', 'coordinates': [hull.tolist()]})
-        if buffer is None:
+        if smoothness is None:
             return result
-        return Polygon(result.buffer(buffer).exterior).buffer(-buffer)
+        return Polygon(result.buffer(smoothness).exterior).buffer(-smoothness)

--- a/geophys_utils/_netcdf_line_utils.py
+++ b/geophys_utils/_netcdf_line_utils.py
@@ -23,7 +23,9 @@ Created on 16/11/2016
 import os
 import numpy as np
 from geophys_utils._netcdf_point_utils import NetCDFPointUtils
+from geophys_utils._concave_hull import concaveHull
 from scipy.spatial.distance import pdist
+from shapely.geometry import shape, Polygon
 import logging
 import netCDF4
 
@@ -378,4 +380,19 @@ class NetCDFLineUtils(NetCDFPointUtils):
             
         #logger.debug('line_index: {}'.format(line_index))
         return line_index
-    
+
+    def get_concave_hull(self, buffer=None):
+        def end_points(ld):
+            coords = ld['coordinates']
+            assert len(coords.shape) == 2
+            if coords.shape[0] == 1:
+                return coords
+            else:
+                return coords[[0, -1]]
+
+        points = np.concatenate([end_points(ld) for _, ld in self.get_lines(variables=[])])
+        hull = concaveHull(points)
+        result = shape({'type': 'Polygon', 'coordinates': [hull.tolist()]})
+        if buffer is None:
+            return result
+        return Polygon(result.buffer(buffer).exterior).buffer(-buffer)

--- a/geophys_utils/_netcdf_point_utils.py
+++ b/geophys_utils/_netcdf_point_utils.py
@@ -35,6 +35,8 @@ from geophys_utils._crs_utils import transform_coords, get_utm_wkt
 from geophys_utils._transect_utils import utm_coords, coords2distance
 from geophys_utils._netcdf_utils import NetCDFUtils
 from geophys_utils._polygon_utils import points2convex_hull
+from geophys_utils._concave_hull import concaveHull
+from shapely.geometry import shape
 from scipy.spatial.ckdtree import cKDTree
 import logging
 
@@ -964,6 +966,10 @@ class NetCDFPointUtils(NetCDFUtils):
             logger.debug('Finished indexing full dataset into KDTree.')
         return self._kdtree
 
+    def get_concave_hull(self):
+        hull = concaveHull(self.xycoords)
+        return shape({'type': 'Polygon', 'coordinates': [hull.tolist()]})
+
 
 def main(debug=True):
     '''
@@ -1013,4 +1019,3 @@ if __name__ == '__main__':
         logger.debug('Logging handlers set up for logger {}'.format(logger.name))
 
     main()        
-    

--- a/geophys_utils/test/test_netcdf_grid_utils.py
+++ b/geophys_utils/test/test_netcdf_grid_utils.py
@@ -27,6 +27,7 @@ import os
 import netCDF4
 import numpy as np
 from geophys_utils._netcdf_grid_utils import NetCDFGridUtils
+from shapely.geometry.polygon import Polygon
 
 netcdf_grid_utils = None
 
@@ -90,6 +91,11 @@ class TestNetCDFGridUtilsFunctions1(unittest.TestCase):
         print('Testing sample_transect function')
         #TODO: Finish this!
         #transect_samples = netcdf_grid_utils.sample_transect(transect_vertices, crs=None, sample_metres=None)
+
+    def test_concave_hull(self):
+        print('Testing concave hull')
+        assert isinstance(netcdf_grid_utils.get_concave_hull(), Polygon)
+
 
 # Define test suites
 def test_suite():

--- a/geophys_utils/test/test_netcdf_line_utils.py
+++ b/geophys_utils/test/test_netcdf_line_utils.py
@@ -28,6 +28,7 @@ import re
 import netCDF4
 import numpy as np
 from geophys_utils._netcdf_line_utils import NetCDFLineUtils
+from shapely.geometry.polygon import Polygon
 
 netcdf_line_utils = None
 
@@ -82,6 +83,10 @@ class TestNetCDFLineUtilsFunctions1(unittest.TestCase):
             count += 1
             if count >= 2:
                 break
+
+    def test_concave_hull(self):
+        print('Testing concave hull')
+        assert isinstance(netcdf_line_utils.get_concave_hull(), Polygon)
 
 
 class TestNetCDFLineUtilsFunctions2(unittest.TestCase):

--- a/geophys_utils/test/test_netcdf_point_utils.py
+++ b/geophys_utils/test/test_netcdf_point_utils.py
@@ -94,7 +94,11 @@ class TestNetCDFPointUtilsFunctions1(unittest.TestCase):
         spatial_mask = netcdf_point_utils.get_spatial_mask(TEST_BOUNDS)
         #print(spatial_mask)
         assert np.count_nonzero(spatial_mask) == SPATIAL_MASK_COUNT, 'Unexpected spatial mask count'
-        
+
+    def test_concave_hull(self):
+        print('Testing concave hull')
+        raise ValueError(netcdf_point_utils.get_concave_hull())
+
 
 class TestNetCDFPointUtilsGridFunctions(unittest.TestCase):
     """Unit tests for geophys_utils._netcdf_point_utils functions"""


### PR DESCRIPTION
- Add method `get_concave_hull` to `NetCDFPointUtils`, `NetCDFLineUtils`, and `NetCDFGridUtils`.

The algorithm is adapted from [Adriano Moreira and Maribel Yasmina Santos 2007](https://pdfs.semanticscholar.org/2397/17005c3ebd5d6a42fc833daf97a0edee1ce4.pdf).