### PR TITLE
Point access speedup

### DIFF
--- a/geophys_utils/_netcdf_grid_utils.py
+++ b/geophys_utils/_netcdf_grid_utils.py
@@ -258,41 +258,41 @@ class NetCDFGridUtils(NetCDFUtils):
         indices = np.array(self.get_indices_from_coords(coordinates, wkt))
         
 #        return data_variable[indices[:,0], indices[:,1]].diagonal() # This could get too big
-        # try:
-        # Make this a vectorised operation for speed (one query for as many
-        # points as possible)
-        # Array of valid index pairs only
-        index_array = np.array(
-            [index_pair for index_pair in indices if index_pair is not None])
-        assert len(index_array.shape) == 2 and index_array.shape[
-            1] == 2, 'Not an iterable containing index pairs'
-        # Boolean mask indicating which index pairs are valid
-        mask_array = np.array([(index_pair is not None)
-                                for index_pair in indices])
-        # Array of values read from variable
-        value_array = np.ones(shape=(len(index_array)),
-                                dtype=data_variable.dtype) * no_data_value
-        # Final result array including no-data for invalid index pairs
-        result_array = np.ones(
-            shape=(len(mask_array)), dtype=data_variable.dtype) * no_data_value
-        start_index = 0
-        end_index = _max_index(index_array, start_index, data_variable, max_bytes)
-        while start_index < len(index_array):
-            i00 = min(index_array[start_index,0],index_array[end_index,0])
-            i01 = max(index_array[start_index,0],index_array[end_index,0])+1
-            i10 = min(index_array[start_index,1],index_array[end_index,1])
-            i11 = max(index_array[start_index,1],index_array[end_index,1])+1
-            query_result = data_variable[i00:i01, i10:i11]
-            residx0 = index_array[start_index:end_index+1,0] - index_array[start_index,0]
-            residx1 = index_array[start_index:end_index+1,1] - index_array[start_index,1]
-            value_array[start_index:end_index+1] = query_result[residx0, residx1]
-            start_index = end_index + 1
+        try:
+            # Make this a vectorised operation for speed (one query for as many
+            # points as possible)
+            # Array of valid index pairs only
+            index_array = np.array(
+                [index_pair for index_pair in indices if index_pair is not None])
+            assert len(index_array.shape) == 2 and index_array.shape[
+                1] == 2, 'Not an iterable containing index pairs'
+            # Boolean mask indicating which index pairs are valid
+            mask_array = np.array([(index_pair is not None)
+                                    for index_pair in indices])
+            # Array of values read from variable
+            value_array = np.ones(shape=(len(index_array)),
+                                    dtype=data_variable.dtype) * no_data_value
+            # Final result array including no-data for invalid index pairs
+            result_array = np.ones(
+                shape=(len(mask_array)), dtype=data_variable.dtype) * no_data_value
+            start_index = 0
             end_index = _max_index(index_array, start_index, data_variable, max_bytes)
+            while start_index < len(index_array):
+                i00 = min(index_array[start_index,0],index_array[end_index,0])
+                i01 = max(index_array[start_index,0],index_array[end_index,0])+1
+                i10 = min(index_array[start_index,1],index_array[end_index,1])
+                i11 = max(index_array[start_index,1],index_array[end_index,1])+1
+                query_result = data_variable[i00:i01, i10:i11]
+                residx0 = index_array[start_index:end_index+1,0] - index_array[start_index,0]
+                residx1 = index_array[start_index:end_index+1,1] - index_array[start_index,1]
+                value_array[start_index:end_index+1] = query_result[residx0, residx1]
+                start_index = end_index + 1
+                end_index = _max_index(index_array, start_index, data_variable, max_bytes)
 
-        result_array[mask_array] = value_array
-        return list(result_array)
-        # except ValueError:
-            # return data_variable[indices[0], indices[1]]
+            result_array[mask_array] = value_array
+            return list(result_array)
+        except:
+            return data_variable[indices[0], indices[1]]
 
     def get_interpolated_value_at_coords(
             self, coordinates, wkt=None, max_bytes=None, variable_name=None):

--- a/geophys_utils/_netcdf_grid_utils.py
+++ b/geophys_utils/_netcdf_grid_utils.py
@@ -20,7 +20,6 @@ Created on 14Sep.,2016
 
 @author: Alex Ip <Alex.Ip@ga.gov.au>
 '''
-from operator import index
 import numpy as np
 import math
 from scipy.ndimage import map_coordinates
@@ -235,11 +234,6 @@ class NetCDFGridUtils(NetCDFUtils):
 
         return fractional_indices
 
-    def _get_nbytes(self, index_array, start_index, end_index, data_variable): #number of bytes used for an indexing request
-        dx = abs(index_array[end_index,0]-index_array[start_index,0])
-        dy = abs(index_array[end_index,0]-index_array[start_index,0])
-        return dx*dy*data_variable.dtype.itemsize
-
     def get_value_at_coords(self, coordinates, wkt=None,
                             max_bytes=None, variable_name=None):
         '''
@@ -264,52 +258,41 @@ class NetCDFGridUtils(NetCDFUtils):
         indices = np.array(self.get_indices_from_coords(coordinates, wkt))
         
 #        return data_variable[indices[:,0], indices[:,1]].diagonal() # This could get too big
+        # try:
+        # Make this a vectorised operation for speed (one query for as many
+        # points as possible)
+        # Array of valid index pairs only
+        index_array = np.array(
+            [index_pair for index_pair in indices if index_pair is not None])
+        assert len(index_array.shape) == 2 and index_array.shape[
+            1] == 2, 'Not an iterable containing index pairs'
+        # Boolean mask indicating which index pairs are valid
+        mask_array = np.array([(index_pair is not None)
+                                for index_pair in indices])
+        # Array of values read from variable
+        value_array = np.ones(shape=(len(index_array)),
+                                dtype=data_variable.dtype) * no_data_value
+        # Final result array including no-data for invalid index pairs
+        result_array = np.ones(
+            shape=(len(mask_array)), dtype=data_variable.dtype) * no_data_value
+        start_index = 0
+        end_index = _max_index(index_array, start_index, data_variable, max_bytes)
+        while start_index < len(index_array):
+            i00 = min(index_array[start_index,0],index_array[end_index,0])
+            i01 = max(index_array[start_index,0],index_array[end_index,0])+1
+            i10 = min(index_array[start_index,1],index_array[end_index,1])
+            i11 = max(index_array[start_index,1],index_array[end_index,1])+1
+            query_result = data_variable[i00:i01, i10:i11]
+            residx0 = index_array[start_index:end_index+1,0] - index_array[start_index,0]
+            residx1 = index_array[start_index:end_index+1,1] - index_array[start_index,1]
+            value_array[start_index:end_index+1] = query_result[residx0, residx1]
+            start_index = end_index + 1
+            end_index = _max_index(index_array, start_index, data_variable, max_bytes)
 
-        # Allow for the fact that the NetCDF advanced indexing will pull back
-        # n^2 cells rather than n
-        max_points = max(
-            int(math.sqrt(max_bytes / data_variable.dtype.itemsize)), 1)
-        try:
-            # Make this a vectorised operation for speed (one query for as many
-            # points as possible)
-            # Array of valid index pairs only
-            index_array = np.array(
-                [index_pair for index_pair in indices if index_pair is not None])
-            assert len(index_array.shape) == 2 and index_array.shape[
-                1] == 2, 'Not an iterable containing index pairs'
-            # Boolean mask indicating which index pairs are valid
-            mask_array = np.array([(index_pair is not None)
-                                   for index_pair in indices])
-            # Array of values read from variable
-            value_array = np.ones(shape=(len(index_array)),
-                                  dtype=data_variable.dtype) * no_data_value
-            # Final result array including no-data for invalid index pairs
-            result_array = np.ones(
-                shape=(len(mask_array)), dtype=data_variable.dtype) * no_data_value
-            start_index = 0
-            end_index = 1
-            while self._get_nbytes(index_array, start_index, end_index, data_variable) < max_bytes:
-                end_index += 1
-            end_index = min(end_index, len(index_array))
-            while start_index < len(index_array):
-                # N.B: ".diagonal()" is required because NetCDF doesn't do advanced indexing exactly like numpy
-                # Hack is required to take values from leading diagonal. Requires n^2 elements retrieved instead of n. Not good, but better than whole array
-                # TODO: Think of a better way of doing this
-                query_result = data_variable[
-                    (index_array[start_index:end_index, 0], index_array[start_index:end_index, 1])]
-                residx0 = index_array[start_index:end_index,0] - index_array[start_index,0]
-                residx1 = index_array[start_index:end_index,1] - index_array[start_index,1]
-                value_array[start_index:end_index] = query_result[residx0, residx1]
-                start_index = end_index
-                end_index = start_index + 1
-                while self._get_nbytes(index_array, start_index, end_index, data_variable) < max_bytes:
-                    end_index += 1
-                end_index = min(end_index, len(index_array))
-
-            result_array[mask_array] = value_array
-            return list(result_array)
-        except IndexError:
-            return data_variable[indices[0], indices[1]]
+        result_array[mask_array] = value_array
+        return list(result_array)
+        # except ValueError:
+            # return data_variable[indices[0], indices[1]]
 
     def get_interpolated_value_at_coords(
             self, coordinates, wkt=None, max_bytes=None, variable_name=None):
@@ -916,6 +899,17 @@ class NetCDFGridUtils(NetCDFUtils):
             logger.debug("current_min: {}".format(current_min))
         return current_min, current_max
 
+def _max_index(index_array, start_index, data_variable, max_bytes):
+    #find the maximum ending index to use for a request under max_bytes
+    end_index = start_index
+    dbytes = data_variable.dtype.itemsize
+    nbytes = 0
+    while end_index < len(index_array) and nbytes <= max_bytes:
+        dx = abs(index_array[end_index,0]-index_array[start_index,0]) + 1
+        dy = abs(index_array[end_index,0]-index_array[start_index,0]) + 1
+        nbytes = dx*dy*dbytes
+        end_index += 1
+    return max(start_index, end_index - 1)
 
 def main():
     '''

--- a/geophys_utils/test/test_netcdf_grid_utils.py
+++ b/geophys_utils/test/test_netcdf_grid_utils.py
@@ -32,15 +32,19 @@ from shapely.geometry.polygon import Polygon
 netcdf_grid_utils = None
 
 NC_PATH = 'test_grid.nc'    
-MAX_BYTES = 1600
+MAX_BYTES_SM = 100
+MAX_BYTES_LG = 5000
 MAX_ERROR = 0.000001
 TEST_COORDS = (148.213, -36.015)
 TEST_MULTI_COORDS = np.array([[148.213, -36.015], [148.516, -35.316]])
+TEST_MANY_COORDS = np.array([[148.484, -35.352],
+    [148.328, -35.428], [148.436, -35.744], [148.300, -35.436]])
 TEST_INDICES = [1, 1]
 TEST_MULTI_INDICES = [[1, 1], [176, 77]]
 TEST_FRACTIONAL_INDICES = [1.25, 1.25]
 TEST_VALUE = -99999.
 TEST_MULTI_VALUES = [-99999.0, -134.711334229]
+TEST_MANY_VALS = [-136.13321, -31.7626, -58.755764, -90.484276]
 TEST_INTERPOLATED_VALUE = -99997.6171875
     
 class TestNetCDFGridUtilsConstructor(unittest.TestCase):
@@ -81,6 +85,18 @@ class TestNetCDFGridUtilsFunctions1(unittest.TestCase):
         print('Testing get_value_at_coords function with multiple coordinates {}'.format(TEST_MULTI_COORDS))
         multi_values = netcdf_grid_utils.get_value_at_coords(TEST_MULTI_COORDS)
         assert (np.abs(np.array(multi_values) - np.array(TEST_MULTI_VALUES)) < MAX_ERROR).all(), 'Incorrect retrieved value: {} instead of {}'.format(multi_values, TEST_MULTI_VALUES)
+
+        print('Testing get_value_at_coords with long coordinate list {}'.format(TEST_MANY_COORDS))
+        many_values = netcdf_grid_utils.get_value_at_coords(TEST_MANY_COORDS)
+        assert (np.abs(np.array(many_values) - np.array(TEST_MANY_VALS)) < MAX_ERROR).all(), 'Incorrect retrieved value: {} instead of {}'.format(many_values, TEST_MANY_VALS)
+
+        print('Testing get_value_at_coords with long coordinate list {} and request size {} bytes'.format(TEST_MANY_COORDS, MAX_BYTES_SM))
+        many_values = netcdf_grid_utils.get_value_at_coords(TEST_MANY_COORDS, max_bytes=MAX_BYTES_SM)
+        assert (np.abs(np.array(many_values) - np.array(TEST_MANY_VALS)) < MAX_ERROR).all(), 'Incorrect retrieved value: {} instead of {}'.format(many_values, TEST_MANY_VALS)
+        
+        print('Testing get_value_at_coords with long coordinate list {} and request size {} bytes'.format(TEST_MANY_COORDS, MAX_BYTES_LG))
+        many_values = netcdf_grid_utils.get_value_at_coords(TEST_MANY_COORDS, max_bytes=MAX_BYTES_LG)
+        assert (np.abs(np.array(many_values) - np.array(TEST_MANY_VALS)) < MAX_ERROR).all(), 'Incorrect retrieved value: {} instead of {}'.format(many_values, TEST_MANY_VALS)
 
     def test_get_interpolated_value_at_coords(self):
         print('Testing get_interpolated_value_at_coords function')


### PR DESCRIPTION
This will address the issue raised in #8. The problem there is that netCDF really doesn't like "fancy indexing" (see e.g. [here](https://stackoverflow.com/questions/42422804/need-to-quickly-subset-a-very-big-ncdf-using-a-set-of-coordinates)), where an attempt is made to access a bunch of separate small areas in the file (e.g. a list of separated points). This is only going to be more of a problem when the file is being supplied by a remote THREDDS server as reported in the issue - if `max_bytes` is set large enough in the call to `get_value_at_coords` then the server will time out attempting to do the fancy indexing, and the only alternative is to set a small maximum request size that gets a few points each time, which is also quite slow.

This PR changes this by indexing the dataset with contiguous slices if `max_bytes` allows, which is processed much, much faster. I tested with the notebook in `examples/2_geophys_netcdf_grid_utils_demo.ipynb` (this uses the same dataset referenced in #8) and was able to retrieve 466 points at 10 km spacing in less than 2 seconds with a fast connection to NCI and `max_bytes=50000000` (50 MB), compared to a minimum of 6.9 seconds with the current implementation using the minimum request size of `max_bytes=1`.

The changes aren't quite ready yet because the computation of the slice indices assumes that the list of points is "sorted" in a way that the rectangle bounded by the `i`th point and `j`th point is entirely contained in the rectangle bounded by the `i`th point and `j+1`th point. This will probably hold for lists of points that are along an almost straight line, but not otherwise.